### PR TITLE
TensorFlow V2 Compatibility

### DIFF
--- a/best_checkpoint_copier/__init__.py
+++ b/best_checkpoint_copier/__init__.py
@@ -55,7 +55,7 @@ class BestCheckpointCopier(tf.estimator.Exporter):
     self._copyCheckpoint(checkpoint)
 
   def _log(self, statement):
-    tf.logging.info('[{}] {}'.format(self.__class__.__name__, statement))
+    tf.compat.v1.logging.info('[{}] {}'.format(self.__class__.__name__, statement))
 
   def _pruneCheckpoints(self, checkpoint):
     destination_dir = self._destinationDir(checkpoint)


### PR DESCRIPTION
I tried BestCheckpointCopier but tf.logging no longer exists on TensorFlow 2 and newer, so I changed the logger to use tf.compat.v1.logging instead. No other changes are needed as far as I can tell.